### PR TITLE
changed middleware entrypoint parameter from string to object

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,18 +27,30 @@ $ npm install --save express-actuator
 ## Usage
 
 ```js
-var actuator = require('express-actuator');
-
-var app = express();
+const actuator = require('express-actuator');
+const app = express();
 
 app.use(actuator());
 ```
 
-If you want the endpoints to be available on a base path you can do so:
+## Configuring Actuator
+
+```js
+const options = {
+    basePath: '/management' // It will set /management/info instead of /info
+};
+
+app.use(actuator(options));
+```
+
+### Deprecated mode
+To have backward compatibility with previous versions (<= 1.2.0) the legacy way is still available:
 
 ```js
 app.use(actuator('/management')); // It will set /management/info instead of /info
 ```
+
+> **_IMPORTANT:_** Deprecated mode will be remove in future versions.
 
 ## Request Examples
 ### info
@@ -58,9 +70,9 @@ app.use(actuator('/management')); // It will set /management/info instead of /in
     }    
 }
 ```
-IMPORTANT: To get this information the middleware have some sort of logic:
-1. When the express app is executed with ```node app.js``` or ```npm start``` the module will look for a file named package.json where the node command was launched.
-2. Git information will show only if exists a ```git.properties``` file where the app was launched. You can use [node-git-info](https://www.npmjs.com/package/node-git-info) to generate this file.
+> **_IMPORTANT:_** To get this information the middleware have some sort of logic:
+>1. When the express app is executed with ```node app.js``` or ```npm start``` the module will look for a file named package.json where the node command was launched.
+>2. Git information will show only if exists a ```git.properties``` file where the app was launched. You can use [node-git-info](https://www.npmjs.com/package/node-git-info) to generate this file.
 
 ### metrics
 ```json

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ To have backward compatibility with previous versions (<= 1.2.0) the legacy way 
 app.use(actuator('/management')); // It will set /management/info instead of /info
 ```
 
-> **_IMPORTANT:_** Deprecated mode will be remove in future versions.
+> **_IMPORTANT:_** Deprecated mode will be removed in the next major version.
 
 ## Request Examples
 ### info

--- a/lib/actuatorMiddleware.js
+++ b/lib/actuatorMiddleware.js
@@ -5,27 +5,33 @@ const infoRoute = require('./infoRoute');
 const metricsRoute = require('./metricsRoute');
 const healthRoute = require('./healthRoute');
 
-module.exports = function actuatorMiddleware(basePath) {
+const defaults = {
+    basePath: ''
+};
+
+module.exports = function actuatorMiddleware(options) {
     const router = express.Router();
 
-    const basePathSanitized = sanitize(basePath);
+    const opts = sanitizeOptions(options);
 
-    router.get(basePathSanitized + '/info', infoRoute);
-    router.get(basePathSanitized + '/metrics', metricsRoute);
-    router.get(basePathSanitized + '/health', healthRoute);
+    router.get(opts.basePath + '/info', infoRoute);
+    router.get(opts.basePath + '/metrics', metricsRoute);
+    router.get(opts.basePath + '/health', healthRoute);
 
     return router;
 };
 
-function sanitize(basePath) {
-    let basePathSanitized = basePath;
+function sanitizeOptions(options) {
+    let opts;
 
-    if (basePath === undefined) {
-        basePathSanitized = '';
+    if (options !== undefined && typeof options === 'string') {
+        opts = {
+            basePath: options
+        }
     }
-    else if (basePath === '') {
-        basePathSanitized = basePath;
+    else {
+        opts = Object.assign({}, defaults, options);
     }
 
-    return basePathSanitized;
+    return opts;
 }

--- a/lib/actuatorMiddleware.js
+++ b/lib/actuatorMiddleware.js
@@ -12,7 +12,7 @@ const defaults = {
 module.exports = function actuatorMiddleware(options) {
     const router = express.Router();
 
-    const opts = sanitizeOptions(options);
+    const opts = sanitize(options);
 
     router.get(opts.basePath + '/info', infoRoute);
     router.get(opts.basePath + '/metrics', metricsRoute);
@@ -21,7 +21,7 @@ module.exports = function actuatorMiddleware(options) {
     return router;
 };
 
-function sanitizeOptions(options) {
+function sanitize(options) {
     let opts;
 
     if (options !== undefined && typeof options === 'string') {

--- a/test/functional/basepath.test.js
+++ b/test/functional/basepath.test.js
@@ -7,9 +7,9 @@ const actuator = require('../../lib/actuatorMiddleware.js');
 
 let app;
 
-describe('basePath', function() {
+describe('request basePath as string', function() {
 
-    describe('disabled', function() {
+    describe('if is not set', function() {
         beforeEach(function () {
             app = express();
             app.use(actuator());
@@ -40,7 +40,7 @@ describe('basePath', function() {
         });
     });
 
-    describe('enabled', function() {
+    describe('if it is set', function() {
         beforeEach(function () {
             app = express();
             app.use(actuator('/management'));

--- a/test/functional/basepath.test.js
+++ b/test/functional/basepath.test.js
@@ -7,89 +7,91 @@ const actuator = require('../../lib/actuatorMiddleware.js');
 
 let app;
 
-describe('basePath disable', function() {
-    beforeEach(function () {
-        app = express();
-        app.use(actuator());
+describe('basePath', function() {
+
+    describe('disabled', function() {
+        beforeEach(function () {
+            app = express();
+            app.use(actuator());
+        });
+
+        afterEach(function () {
+            app.close;
+        });
+
+        it('should return 200 when basePath not requested', function (done) {
+            request(app)
+                .get('/health')
+                .end(function (err, res) {
+                    expect(res.statusCode).to.equal(200);
+                    expect(res.headers['content-type']).to.equal('application/json; charset=utf-8');
+                    expect(res.body.status).to.equal("UP");
+                    done();
+                });
+        });
+
+        it('should return 404 when basePath requested', function (done) {
+            request(app)
+                .get('/management/health')
+                .end(function (err, res) {
+                    expect(res.statusCode).to.equal(404);
+                    done();
+                });
+        });
     });
 
-    afterEach(function () {
-        app.close;
-    });
+    describe('enabled', function() {
+        beforeEach(function () {
+            app = express();
+            app.use(actuator('/management'));
+        });
 
-    it('should return 200 when basePath not requested', function (done) {
-        request(app)
-            .get('/health')
-            .end(function (err, res) {
-                expect(res.statusCode).to.equal(200);
-                expect(res.headers['content-type']).to.equal('application/json; charset=utf-8');
-                expect(res.body.status).to.equal("UP");
-                done();
-            });
-    });
+        afterEach(function () {
+            app.close;
+        });
 
-    it('should return 404 when basePath requested', function (done) {
-        request(app)
-            .get('/management/health')
-            .end(function (err, res) {
-                expect(res.statusCode).to.equal(404);
-                done();
-            });
-    });
-});
+        it('should return 200 when basePath requested', function (done) {
+            request(app)
+                .get('/management/health')
+                .end(function (err, res) {
+                    expect(res.statusCode).to.equal(200);
+                    expect(res.headers['content-type']).to.equal('application/json; charset=utf-8');
+                    expect(res.body.status).to.equal("UP");
+                    done();
+                });
+        });
 
-describe('basePath enable', function() {
-    beforeEach(function () {
-        app = express();
-        app.use(actuator('/management'));
-    });
+        it('should return 404 when basePath not requested', function (done) {
+            request(app)
+                .get('/health')
+                .end(function (err, res) {
+                    expect(res.statusCode).to.equal(404);
+                    done();
+                });
+        });
 
-    afterEach(function () {
-        app.close;
-    });
+        it('should return 200 when basePath is empty', function (done) {
+            app.use(actuator(''));
+            request(app)
+                .get('/health')
+                .end(function (err, res) {
+                    expect(res.statusCode).to.equal(200);
+                    expect(res.headers['content-type']).to.equal('application/json; charset=utf-8');
+                    expect(res.body.status).to.equal("UP");
+                    done();
+                });
+        });
 
-    it('should return 200 when basePath requested', function(done) {
-        request(app)
-            .get('/management/health')
-            .end(function(err, res) {
-                expect(res.statusCode).to.equal(200);
-                expect(res.headers['content-type']).to.equal('application/json; charset=utf-8');
-                expect(res.body.status).to.equal("UP");
-                done();
-            });
+        it('should return 200 when basePath doesn\'t have slash', function (done) {
+            app.use(actuator('management'));
+            request(app)
+                .get('/management/health')
+                .end(function (err, res) {
+                    expect(res.statusCode).to.equal(200);
+                    expect(res.headers['content-type']).to.equal('application/json; charset=utf-8');
+                    expect(res.body.status).to.equal("UP");
+                    done();
+                });
+        });
     });
-
-    it('should return 404 when basePath not requested', function(done) {
-        request(app)
-            .get('/health')
-            .end(function(err, res) {
-                expect(res.statusCode).to.equal(404);
-                done();
-            });
-    });
-
-    it('should return 200 when basePath is empty', function(done) {
-        app.use(actuator(''));
-        request(app)
-            .get('/health')
-            .end(function(err, res) {
-                expect(res.statusCode).to.equal(200);
-                expect(res.headers['content-type']).to.equal('application/json; charset=utf-8');
-                expect(res.body.status).to.equal("UP");
-                done();
-            });
-    });
-
-    it('should return 200 when basePath doesn\'t have slash', function(done) {
-        app.use(actuator('management'));
-        request(app)
-            .get('/management/health')
-            .end(function(err, res) {
-                expect(res.statusCode).to.equal(200);
-                expect(res.headers['content-type']).to.equal('application/json; charset=utf-8');
-                expect(res.body.status).to.equal("UP");
-                done();
-            });
-    });
-
 });

--- a/test/functional/options.test.js
+++ b/test/functional/options.test.js
@@ -1,0 +1,54 @@
+'use strict';
+
+const request = require('supertest');
+const express = require('express');
+const expect = require('chai').expect;
+const actuator = require('../../lib/actuatorMiddleware.js');
+
+let app;
+
+describe('request basePath within options', function() {
+
+    beforeEach(function () {
+        app = express();
+    });
+
+    afterEach(function () {
+        app.close;
+    });
+
+    it('should return 200 when options has basePath set', function(done) {
+        const options = {
+            basePath: "/management"
+        };
+
+        app.use(actuator(options));
+
+        request(app)
+            .get('/management/health')
+            .end(function (err, res) {
+                expect(res.statusCode).to.equal(200);
+                expect(res.headers['content-type']).to.equal('application/json; charset=utf-8');
+                expect(res.body.status).to.equal("UP");
+                done();
+            });
+    });
+
+    it('should return 200 when options has unknown data', function(done) {
+        const options = {
+            unknownData: "data"
+        };
+
+        app.use(actuator(options));
+
+        request(app)
+            .get('/health')
+            .end(function (err, res) {
+                expect(res.statusCode).to.equal(200);
+                expect(res.headers['content-type']).to.equal('application/json; charset=utf-8');
+                expect(res.body.status).to.equal("UP");
+                done();
+            });
+    });
+
+});

--- a/test/unit/lib/actuatorMiddlewareSpec.test.js
+++ b/test/unit/lib/actuatorMiddlewareSpec.test.js
@@ -29,13 +29,13 @@ describe('actuator middleware', function () {
         let infoRouter = actuator();
 
         expect(infoRouter).to.equal(router);
-        // expect(express.Router).to.have.been.calledOnce;
+        expect(express.Router).to.have.been.calledOnce;
     });
 
     it('should mount the info route on the default endpoint', function () {
         actuator();
 
-        // expect(router.get).to.have.been.calledThrice;
+        expect(router.get).to.have.been.calledThrice;
         expect(router.get).to.have.been.calledWithExactly('/info', infoRoute);
     });
 
@@ -56,7 +56,5 @@ describe('actuator middleware', function () {
         actuator({unknownData: "/test"});
 
         expect(router.get).to.have.been.calledWithExactly('/health', healthRoute);
-        // expect(router.get.body)
-        // console.log(router.)
     });
 });

--- a/test/unit/lib/actuatorMiddlewareSpec.test.js
+++ b/test/unit/lib/actuatorMiddlewareSpec.test.js
@@ -5,6 +5,7 @@ const sinon = require('sinon');
 const expect = chai.expect;
 const express = require('express');
 const infoRoute = require('../../../lib/infoRoute');
+const healthRoute = require('../../../lib/healthRoute');
 const actuator = require('../../../lib/actuatorMiddleware');
 
 chai.use(require('sinon-chai'));
@@ -28,13 +29,13 @@ describe('actuator middleware', function () {
         let infoRouter = actuator();
 
         expect(infoRouter).to.equal(router);
-        expect(express.Router).to.have.been.calledOnce;
+        // expect(express.Router).to.have.been.calledOnce;
     });
 
     it('should mount the info route on the default endpoint', function () {
         actuator();
 
-        expect(router.get).to.have.been.calledThrice;
+        // expect(router.get).to.have.been.calledThrice;
         expect(router.get).to.have.been.calledWithExactly('/info', infoRoute);
     });
 
@@ -43,5 +44,19 @@ describe('actuator middleware', function () {
 
         expect(router.get).to.have.been.calledThrice;
         expect(router.get).to.have.been.calledWithExactly('/foobar/info', infoRoute);
+    });
+
+    it('should mount the health route on the given endpoint when options is set', function () {
+        actuator({basePath: "/management"});
+
+        expect(router.get).to.have.been.calledWithExactly('/management/health', healthRoute);
+    });
+
+    it('should mount the health route on the given endpoint when options has unknown data', function () {
+        actuator({unknownData: "/test"});
+
+        expect(router.get).to.have.been.calledWithExactly('/health', healthRoute);
+        // expect(router.get.body)
+        // console.log(router.)
     });
 });


### PR DESCRIPTION
Added ```options``` as object instead of basePath as string, allowing backward compatibility.
Later on this will solve #3 adding a new field within options to allow the full information of git.properties.
Something similar to this:
```js
const options = {
  infoGitMode: 'full'
}
```
This way anyone can pick the best option related to the security of sensible data.