### PR TITLE
allow formatting of git.commit.time

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,8 @@ All defined options are optional:
 const options = {
     basePath: '/management', // It will set /management/info instead of /info
     infoGitMode: 'simple', // the amount of git information you want to expose, 'simple' or 'full',
-    infoDateFormat: null, // by default, it will show git.commit.time value as is. If defined, moment will format the git.commit.time value. See https://momentjs.com/docs/#/displaying/format/.
+    infoBuildOptions: null, // extra information you want to expose in the build object. Requires an object.
+    infoDateFormat: null, // by default, git.commit.time will show as is defined in git.properties. If infoDateFormat is defined, moment will format git.commit.time. See https://momentjs.com/docs/#/displaying/format/.
     customEndpoints: [] // array of extra endpoints
 };
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,8 @@ All defined options are optional:
 ```js
 const options = {
     basePath: '/management', // It will set /management/info instead of /info
-    infoGitMode: 'simple', // the amount of git information you want to expose, 'simple' or 'full'
+    infoGitMode: 'simple', // the amount of git information you want to expose, 'simple' or 'full',
+    infoDateFormat: null, // by default, it will show git.commit.time value as is. If defined, moment will format the git.commit.time value. See https://momentjs.com/docs/#/displaying/format/.
     customEndpoints: [] // array of extra endpoints
 };
 
@@ -118,7 +119,7 @@ app.use(actuator('/management')); // It will set /management/info instead of /in
         "branch": "master",
         "commit": {
             "id": "329a314",
-            "time": 1478086940000
+            "time": "2016-11-18 08:16:39-0500"
         }
     }
 }

--- a/lib/endpoints/info.js
+++ b/lib/endpoints/info.js
@@ -6,14 +6,16 @@ const moment = require('moment');
 
 let gitMode;
 let dateFormat;
+let buildOptions;
 
 class Info {
-    constructor(infoGitMode, infoDateFormat) {
-        gitMode = infoGitMode;
-        dateFormat = infoDateFormat;
+    constructor(options = {}) {
+        gitMode = options.gitMode;
+        dateFormat = options.dateFormat;
+        buildOptions = options.buildOptions;
     }
     route(req, res) {
-        const build = getBuild();
+        const build = getBuild(buildOptions);
         const git = getGit(gitMode, dateFormat);
 
         res.status(200).json({
@@ -25,7 +27,7 @@ class Info {
 
 module.exports = Info;
 
-function getBuild() {
+function getBuild(options) {
     let packageJson;
     try {
         const packageFile = fs.readFileSync('./package.json', 'utf8');
@@ -36,11 +38,11 @@ function getBuild() {
 
     let build;
     if (packageJson !== undefined) {
-        build = {
+        build = Object.assign({
             name: packageJson.name,
             description: packageJson.description,
-            version: packageJson.version
-        }
+            version: packageJson.version,
+        }, options === Object(options) ? options : {})
     }
 
     return build;

--- a/lib/endpoints/info.js
+++ b/lib/endpoints/info.js
@@ -5,14 +5,16 @@ const properties = require('utils-fs-read-properties');
 const moment = require('moment');
 
 let gitMode;
+let dateFormat;
 
 class Info {
-    constructor(infoGitMode) {
+    constructor(infoGitMode, infoDateFormat) {
         gitMode = infoGitMode;
+        dateFormat = infoDateFormat;
     }
     route(req, res) {
         const build = getBuild();
-        const git = getGit(gitMode);
+        const git = getGit(gitMode, dateFormat);
 
         res.status(200).json({
             build: build,
@@ -44,17 +46,21 @@ function getBuild() {
     return build;
 }
 
-function getGit(infoGitMode) {
+function getGit(infoGitMode, dateFormat) {
     let git;
 
     const data = properties.sync('git.properties');
     if (!(data instanceof Error)) {
+        let time = dateFormat
+            ? moment(data['git.commit.time']).format(dateFormat)
+            : data['git.commit.time'];
+
         if (infoGitMode === 'simple') {
             git = {
                 branch: data['git.branch'],
                 commit: {
                     id: data['git.commit.id.abbrev'],
-                    time: moment(data['git.commit.time'], moment.ISO_8601).valueOf()
+                    time
                 }
             };
         }
@@ -64,7 +70,7 @@ function getGit(infoGitMode) {
                 commit: {
                     id: data['git.commit.id.abbrev'],
                     idFull: data['git.commit.id'],
-                    time: moment(data['git.commit.time'], moment.ISO_8601).valueOf(),
+                    time,
                     user: {
                         email: data['git.commit.user.email'],
                         name: data['git.commit.user.name']

--- a/lib/index.js
+++ b/lib/index.js
@@ -10,6 +10,7 @@ const defaults = {
     basePath: '',
     infoGitMode: 'simple',
     infoDateFormat: null,
+    infoBuildTime: null,
     customEndpoints: [],
 };
 
@@ -17,8 +18,13 @@ module.exports = function actuatorMiddleware(options) {
     const router = express.Router();
 
     const opts = sanitize(options);
+    const info = new Info({
+        gitMode: opts.infoGitMode,
+        dateFormat: opts.infoDateFormat,
+        buildOptions: opts.infoBuildOptions
+    });
 
-    router.get(opts.basePath + '/info', new Info(opts.infoGitMode, opts.infoDateFormat).route);
+    router.get(opts.basePath + '/info', info.route);
     router.get(opts.basePath + '/metrics', new Metrics().route);
     router.get(opts.basePath + '/health', new Health().route);
     opts.customEndpoints.forEach(function (endpoint) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -9,6 +9,7 @@ const Health = require('./endpoints/health');
 const defaults = {
     basePath: '',
     infoGitMode: 'simple',
+    infoDateFormat: null,
     customEndpoints: [],
 };
 
@@ -17,7 +18,7 @@ module.exports = function actuatorMiddleware(options) {
 
     const opts = sanitize(options);
 
-    router.get(opts.basePath + '/info', new Info(opts.infoGitMode).route);
+    router.get(opts.basePath + '/info', new Info(opts.infoGitMode, opts.infoDateFormat).route);
     router.get(opts.basePath + '/metrics', new Metrics().route);
     router.get(opts.basePath + '/health', new Health().route);
     opts.customEndpoints.forEach(function (endpoint) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "express-actuator",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/test/functional/info.test.js
+++ b/test/functional/info.test.js
@@ -70,7 +70,7 @@ describe('GET /info', function() {
                 expect(res.body.build.version).to.equal("1.0.0");
                 expect(res.body.git.branch).to.equal('master');
                 expect(res.body.git.commit.id).to.equal('1a24c24');
-                expect(res.body.git.commit.time).to.equal(1479474999000);
+                expect(res.body.git.commit.time).to.equal('2016-11-18T13:16:39.000Z');
                 done();
             });
     });
@@ -117,7 +117,42 @@ describe('GET /info with infoGitMode', function() {
                 expect(res.body.git.commit.message.short).to.equal('first commit');
                 expect(res.body.git.commit.user.name).to.equal('User Name');
                 expect(res.body.git.branch).to.equal('master');
-                expect(res.body.git.commit.time).to.equal(1479474999000);
+                expect(res.body.git.commit.time).to.equal('2016-11-18T13:16:39.000Z');
+                done();
+            });
+    });
+
+});
+
+describe('GET /info with infoDateFormat', function() {
+    beforeEach(function() {
+        app = express();
+    });
+
+    afterEach(function() {
+        app.close;
+        mock.restore();
+    });
+
+    it('should return git time formatted when infoDateFormat is defined', function(done) {
+        mock({
+            'package.json': '{"name":"testName","description":"testDescription","version":"1.0.0"}',
+            'git.properties': "git.branch=master\ngit.commit.id.abbrev=1a24c24\ngit.commit.time=2016-11-18T13:16:39.000Z"
+        });
+
+        app.use(actuator({infoDateFormat: 'YYYY-MM-DD HH:mm:ss'}));
+
+        request(app)
+            .get('/info')
+            .end(function(err, res) {
+                expect(res.statusCode).to.equal(200);
+                expect(res.headers['content-type']).to.equal('application/json; charset=utf-8');
+                expect(res.body.build.name).to.equal("testName");
+                expect(res.body.build.description).to.equal("testDescription");
+                expect(res.body.build.version).to.equal("1.0.0");
+                expect(res.body.git.branch).to.equal('master');
+                expect(res.body.git.commit.id).to.equal('1a24c24');
+                expect(res.body.git.commit.time).to.equal('2016-11-18 08:16:39');
                 done();
             });
     });

--- a/test/functional/info.test.js
+++ b/test/functional/info.test.js
@@ -140,7 +140,7 @@ describe('GET /info with infoDateFormat', function() {
             'git.properties': "git.branch=master\ngit.commit.id.abbrev=1a24c24\ngit.commit.time=2016-11-18T13:16:39.000Z"
         });
 
-        app.use(actuator({infoDateFormat: 'YYYY-MM-DD HH:mm:ss'}));
+        app.use(actuator({infoDateFormat: 'YYYY-MM-DD'}));
 
         request(app)
             .get('/info')
@@ -152,9 +152,44 @@ describe('GET /info with infoDateFormat', function() {
                 expect(res.body.build.version).to.equal("1.0.0");
                 expect(res.body.git.branch).to.equal('master');
                 expect(res.body.git.commit.id).to.equal('1a24c24');
-                expect(res.body.git.commit.time).to.equal('2016-11-18 08:16:39');
+                expect(res.body.git.commit.time).to.equal('2016-11-18');
                 done();
             });
     });
 
+});
+
+describe('GET /info with infoBuildOptions', function() {
+    beforeEach(function() {
+        app = express();
+    });
+
+    afterEach(function() {
+        app.close;
+        mock.restore();
+    });
+
+    it('should return build with added infoBuildOptions information when defined', function(done) {
+        mock({
+            'package.json': '{"name":"testName","description":"testDescription","version":"1.0.0"}',
+        });
+
+        app.use(actuator({
+            infoBuildOptions: {
+                test: 'test'
+            }
+        }));
+
+        request(app)
+            .get('/info')
+            .end(function(err, res) {
+                expect(res.statusCode).to.equal(200);
+                expect(res.headers['content-type']).to.equal('application/json; charset=utf-8');
+                expect(res.body.build.name).to.equal("testName");
+                expect(res.body.build.description).to.equal("testDescription");
+                expect(res.body.build.version).to.equal("1.0.0");
+                expect(res.body.build.test).to.equal("test");
+                done();
+            });
+    });
 });


### PR DESCRIPTION
I noticed Springboot `/info` route only reads from `git.properties`. It does not convert it further at runtime. You can modify the timestamp format when you generate `git.properties`, but after that, Springboot just reads it.

```
    <build>
        <finalName>yourprojectname</finalName>
        <plugins>
            <plugin>
                <groupId>pl.project13.maven</groupId>
                <artifactId>git-commit-id-plugin</artifactId>
                <version>3.0.1</version>
                <configuration>
                    <verbose>false</verbose>
                    <dateFormat>yyyy-MM-dd'T'HH:mm:ssZ</dateFormat>
                    <generateGitPropertiesFile>true</generateGitPropertiesFile>
                    <generateGitPropertiesFilename>${project.build.outputDirectory}/git.properties
                    </generateGitPropertiesFilename>
                    <excludeProperties>
                        <excludeProperty>git.remote.origin.url</excludeProperty>
                    </excludeProperties>
                </configuration>
            </plugin>
        </plugins>
    </build>
```

This pom xml setting gives an output like this from Springboot, I just verified:

```
{
  "git": {
    "commit": {
      "time": "2020-07-03T14:55:38Z",
      "id": "...."
    },
    "branch": "master"
  },
  "build": {
    ...
    "time": "2020-07-03T14:56:01.156Z"
  }
}
```

This PR is to make `express-actuator` match what Springboot does. By default, we should show `git.commit.time` as is printed in `git.properties`. And I am providing a new option to format at runtime, `infoDateFormat` (Using [moment format](https://momentjs.com/docs/#/displaying/format/)), if needed.

Using node-git-info, you already print to ISO string. https://github.com/rcruzper/node-git-info/blob/master/lib/gitCommands.js#L44

I am thinking of putting the date formatting capability on node-git-info directly and just have express-actuator read the result.