### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ You can add your own validations using the `customEndpoints` option:
 const options = {
     customEndpoints: [
         {
-            id: 'dependecies', // used as endpoint /dependencies or ${basePath}/dependencies
+            id: 'dependencies', // used as endpoint /dependencies or ${basePath}/dependencies
             controller: (req, res) => { // Controller to be called when accessing this endpoint
                 // Your custom code here
             }


### PR DESCRIPTION
The README needs a small typo fix in on of the examples